### PR TITLE
Use the filename when no title attribute is present

### DIFF
--- a/walk.go
+++ b/walk.go
@@ -44,7 +44,11 @@ func walk(root, ext string, index bool, ignorePaths map[string]struct{}) (res []
 				if parsedTitle, ok := frontmatter["title"]; ok {
 					title = parsedTitle.(string)
 				} else {
-					title = "Untitled Page"
+					title = strings.TrimSuffix(d.Name(), ".md")
+
+					if title == "" {
+						title = "No Title Specified"
+					}
 				}
 
 				// check if page is private


### PR DESCRIPTION
Hey @jackyzha0, I found that for my digital garden use case many of my files did not have the necessary title frontmatter and this seemed like a sensible default (at least for me). If it's useful to you, feel free to use it, if not my feelings won't be hurt either. 