### PR TITLE
fix: unescape target URL

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/PuerkitoBio/goquery"
 	"io/ioutil"
+	"net/url"
 	"strings"
 )
 
@@ -35,12 +36,13 @@ func parse(dir, pathPrefix string) []Link {
 		}
 
 		target = processTarget(target)
+		unescapedTarget, _ := url.PathUnescape(target)
 		source := processSource(trim(dir, pathPrefix, ".md"))
 
 		// fmt.Printf("  '%s' => %s\n", source, target)
 		links = append(links, Link{
 			Source: source,
-			Target: target,
+			Target: unescapedTarget,
 			Text:   text,
 		})
 		n++


### PR DESCRIPTION
For URLs in non-ascii, the target name should un-escaped to be shown properly.

For example, before this commit, target written in Arabic "`/البرمجة`" is shown as `/%D8%A7%D9%84%D8%A8%D8%B1%D9%85%D8%AC%D8%A9`.

After this fix (last link at bottom right):
![image](https://user-images.githubusercontent.com/17043808/185864625-ea030a04-e662-4002-b9f2-bab63c59e59a.png)
