### PR TITLE
Fix wikilink processing bug

### DIFF
--- a/util.go
+++ b/util.go
@@ -23,9 +23,9 @@ func processTarget(source string) string {
 	if strings.HasPrefix(source, "/") {
 		return strings.TrimSuffix(source, ".md")
 	}
-	res := "/" + strings.TrimSuffix(strings.TrimSuffix(source, ".html"), ".md")
+	res := strings.Split(source, "#")[0]
+	res = "/" + strings.TrimSuffix(strings.TrimSuffix(res, ".html"), ".md")
 	res, _ = url.PathUnescape(res)
-	res = strings.Split(res, "#")[0]
 	res = strings.TrimSpace(res)
 	res = UnicodeSanitize(res)
 	return strings.ReplaceAll(url.PathEscape(res), "%2F", "/")


### PR DESCRIPTION
- With WikiLink header syntax such as `[[file.md#header-name|link name]]`, the target becomes `file.md.html#header-name`, so we must split the target by # before stripping .md.html. 
- Previously we were attempting to strip .md.html and then split by #, so all wikilinks to specific tags were not processed properly (and thus being treated as external links)