### PR TITLE
Remove dot from fragment

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,9 @@ var md goldmark.Markdown
 
 func init() {
 	md = goldmark.New(
-		goldmark.WithExtensions(&wikilink.Extender{}),
+		goldmark.WithExtensions(&wikilink.Extender{
+			Resolver: QuartzResolver,
+		}),
 	)
 }
 

--- a/resolver.go
+++ b/resolver.go
@@ -1,5 +1,3 @@
-package wikilink
-
 import "path/filepath"
 var QuartzResolver Resolver = quartzResolver{}
 

--- a/resolver.go
+++ b/resolver.go
@@ -1,3 +1,5 @@
+package main
+
 import "path/filepath"
 var QuartzResolver Resolver = quartzResolver{}
 

--- a/resolver.go
+++ b/resolver.go
@@ -27,6 +27,7 @@ func (quartzResolver) ResolveWikilink(n *wikilink.Node) ([]byte, error) {
 	}
 	if len(n.Fragment) > 0 {
 		i += copy(dest[i:], _hash)
+		fmt.Println(n.Fragment)
 		for f := 0; f < len(n.Fragment); f++ {
 			fmt.Println(string(n.Fragment[f]))
 			if string(n.Fragment[f]) != "." {
@@ -34,6 +35,7 @@ func (quartzResolver) ResolveWikilink(n *wikilink.Node) ([]byte, error) {
 				i++
 			}
 		}
+		fmt.Println(dest[:i])
 	}
 	return dest[:i], nil
 }

--- a/resolver.go
+++ b/resolver.go
@@ -20,13 +20,13 @@ func (quartzResolver) ResolveWikilink(n *Node) ([]byte, error) {
 	}
 	if len(n.Fragment) > 0 {
 		i += copy(dest[i:], _hash)
-    for f := 0; f < len(n.Fragment); f++ {
-      if n.Fragment[f] == '.' {
-        continue
-      }
-      dest[i] = n.Fragment[f]
-      i++
-    }
+		for f := 0; f < len(n.Fragment); f++ {
+			if n.Fragment[f] == '.' {
+				continue
+			}
+			dest[i] = n.Fragment[f]
+			i++
+		}
 	}
 	return dest[:i], nil
 }

--- a/resolver.go
+++ b/resolver.go
@@ -27,7 +27,7 @@ func (quartzResolver) ResolveWikilink(n *wikilink.Node) ([]byte, error) {
 	if len(n.Fragment) > 0 {
 		i += copy(dest[i:], _hash)
 		for f := 0; f < len(n.Fragment); f++ {
-			if n.Fragment[f] == '.' {
+			if n.Fragment[f] == "." {
 				continue
 			}
 			dest[i] = n.Fragment[f]

--- a/resolver.go
+++ b/resolver.go
@@ -28,7 +28,7 @@ func (quartzResolver) ResolveWikilink(n *wikilink.Node) ([]byte, error) {
 	if len(n.Fragment) > 0 {
 		i += copy(dest[i:], _hash)
 		for f := 0; f < len(n.Fragment); f++ {
-			fmt.Println(n.Fragment[f])
+			fmt.Println(string(n.Fragment[f]))
 			if string(n.Fragment[f]) != "." {
 				dest[i] = n.Fragment[f]
 				i++

--- a/resolver.go
+++ b/resolver.go
@@ -27,7 +27,7 @@ func (quartzResolver) ResolveWikilink(n *wikilink.Node) ([]byte, error) {
 	if len(n.Fragment) > 0 {
 		i += copy(dest[i:], _hash)
 		for f := 0; f < len(n.Fragment); f++ {
-			if n.Fragment[f] == "." {
+			if string(n.Fragment[f]) == "." {
 				continue
 			}
 			dest[i] = n.Fragment[f]

--- a/resolver.go
+++ b/resolver.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"path/filepath"
 	wikilink "github.com/abhinav/goldmark-wikilink"
 )
@@ -27,6 +28,7 @@ func (quartzResolver) ResolveWikilink(n *wikilink.Node) ([]byte, error) {
 	if len(n.Fragment) > 0 {
 		i += copy(dest[i:], _hash)
 		for f := 0; f < len(n.Fragment); f++ {
+			fmt.Println(n.Fragment[f])
 			if string(n.Fragment[f]) != "." {
 				dest[i] = n.Fragment[f]
 				i++

--- a/resolver.go
+++ b/resolver.go
@@ -1,6 +1,9 @@
 package main
 
-import "path/filepath"
+import (
+	"path/filepath"
+	wikilink "github.com/abhinav/goldmark-wikilink"
+)
 var QuartzResolver Resolver = quartzResolver{}
 
 type Resolver interface {

--- a/resolver.go
+++ b/resolver.go
@@ -1,0 +1,34 @@
+package wikilink
+
+import "path/filepath"
+var QuartzResolver Resolver = quartzResolver{}
+
+type Resolver interface {
+	ResolveWikilink(*Node) (destination []byte, err error)
+}
+
+var _html = []byte(".html")
+
+type quartzResolver struct{}
+
+func (quartzResolver) ResolveWikilink(n *Node) ([]byte, error) {
+	dest := make([]byte, len(n.Target)+len(_html)+len(_hash)+len(n.Fragment))
+	var i int
+	if len(n.Target) > 0 {
+		i += copy(dest, n.Target)
+		if filepath.Ext(string(n.Target)) == "" {
+			i += copy(dest[i:], _html)
+		}
+	}
+	if len(n.Fragment) > 0 {
+		i += copy(dest[i:], _hash)
+    for f := 0; f < len(n.Fragment); f++ {
+      if n.Fragment[f] == '.' {
+        continue
+      }
+      dest[i] = n.Fragment[f]
+      i++
+    }
+	}
+	return dest[:i], nil
+}

--- a/resolver.go
+++ b/resolver.go
@@ -4,14 +4,14 @@ import "path/filepath"
 var QuartzResolver Resolver = quartzResolver{}
 
 type Resolver interface {
-	ResolveWikilink(*Node) (destination []byte, err error)
+	ResolveWikilink(*wikilink.Node) (destination []byte, err error)
 }
 
 var _html = []byte(".html")
 
 type quartzResolver struct{}
 
-func (quartzResolver) ResolveWikilink(n *Node) ([]byte, error) {
+func (quartzResolver) ResolveWikilink(n *wikilink.Node) ([]byte, error) {
 	dest := make([]byte, len(n.Target)+len(_html)+len(_hash)+len(n.Fragment))
 	var i int
 	if len(n.Target) > 0 {

--- a/resolver.go
+++ b/resolver.go
@@ -11,6 +11,7 @@ type Resolver interface {
 }
 
 var _html = []byte(".html")
+var _hash = []byte("#")
 
 type quartzResolver struct{}
 

--- a/resolver.go
+++ b/resolver.go
@@ -27,11 +27,10 @@ func (quartzResolver) ResolveWikilink(n *wikilink.Node) ([]byte, error) {
 	if len(n.Fragment) > 0 {
 		i += copy(dest[i:], _hash)
 		for f := 0; f < len(n.Fragment); f++ {
-			if string(n.Fragment[f]) == "." {
-				continue
+			if string(n.Fragment[f]) != "." {
+				dest[i] = n.Fragment[f]
+				i++
 			}
-			dest[i] = n.Fragment[f]
-			i++
 		}
 	}
 	return dest[:i], nil

--- a/resolver.go
+++ b/resolver.go
@@ -27,7 +27,7 @@ func (quartzResolver) ResolveWikilink(n *wikilink.Node) ([]byte, error) {
 	}
 	if len(n.Fragment) > 0 {
 		i += copy(dest[i:], _hash)
-		fmt.Println(n.Fragment)
+		fmt.Println(string(n.Fragment))
 		for f := 0; f < len(n.Fragment); f++ {
 			fmt.Println(string(n.Fragment[f]))
 			if string(n.Fragment[f]) != "." {
@@ -35,7 +35,7 @@ func (quartzResolver) ResolveWikilink(n *wikilink.Node) ([]byte, error) {
 				i++
 			}
 		}
-		fmt.Println(dest[:i])
+		fmt.Println(string(dest[:i]))
 	}
 	return dest[:i], nil
 }


### PR DESCRIPTION
PR for https://github.com/jackyzha0/quartz/issues/318

Changes

- Define `quartzResolver`
  - It copies `n.Fragment` except dot (`.`)
- Use `quartzResolver` as goldmark extension

Sources

- https://pkg.go.dev/go.abhg.dev/goldmark/wikilink#Resolver
- https://github.com/abhinav/goldmark-wikilink/blob/main/resolver.go
