### PR TITLE
Implement basic relative wikilink support

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,21 +2,15 @@ package main
 
 import (
 	"flag"
-	"github.com/BurntSushi/toml"
-	wikilink "github.com/abhinav/goldmark-wikilink"
-	"github.com/yuin/goldmark"
 	"io/ioutil"
 	"path/filepath"
 	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/yuin/goldmark"
 )
 
 var md goldmark.Markdown
-
-func init() {
-	md = goldmark.New(
-		goldmark.WithExtensions(&wikilink.Extender{}),
-	)
-}
 
 type Link struct {
 	Source string `json:"source"`

--- a/parse.go
+++ b/parse.go
@@ -3,13 +3,15 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/PuerkitoBio/goquery"
 	"io/ioutil"
 	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/yuin/goldmark"
 )
 
 // parse single file for links
-func parse(dir, pathPrefix string) []Link {
+func parse(md goldmark.Markdown, fileIndex fileIndex, dir, pathPrefix string) []Link {
 	// read file
 	source, err := ioutil.ReadFile(dir)
 	if err != nil {
@@ -37,8 +39,10 @@ func parse(dir, pathPrefix string) []Link {
 		target = processTarget(target)
 		source := processSource(trim(dir, pathPrefix, ".md"))
 
+		target = fileIndex.resolve(target)
+
 		// fmt.Printf("  '%s' => %s\n", source, target)
-		if !strings.HasPrefix(text, "^"){
+		if !strings.HasPrefix(text, "^") {
 			links = append(links, Link{
 				Source: source,
 				Target: target,


### PR DESCRIPTION
Closes #35. This allows hugo-obsidian to intuit absolute paths from unanchored wikilink paths. Previously, a note at `directory/note.md` would need to be linked using `[[directory/note]]` in order for the link to be recognized by this tool. This change allows the shorter `[[note]]` link to be used. This is accomplished by first walking the directory tree and storing absolute paths for every path basename, and using this to substitute link names before rendering them.

There's no test infrastructure for this project, but IWOMM